### PR TITLE
bugfix: @libsql/hrana-client 패키지의 LICENSE 파일을 JavaScript 파일로 잘못 인식 webpack 으로 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint"
   },


### PR DESCRIPTION
수정 내용: 빌드 오류 해결 - 터보팩 -> 웹팩
@libsql/hrana-client 패키지의 LICENSE 파일을 JavaScript 파일로 잘못 인식 webpack 으로 변경